### PR TITLE
fix: TODO消化 (#54)

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -19,13 +19,10 @@ class GroupsController < ApplicationController
     @group = current_user.owned_groups.build(group_params)
     authorize @group
 
-    # TODO: 同一トランザクション内で処理を行うようにする
-    if @group.save
-      @group.add_owner_as_member
-      redirect_to @group, notice: 'グループが作成されました。'
-    else
-      render :new, status: :unprocessable_content
-    end
+    @group.process_create!
+    redirect_to @group, notice: 'グループが作成されました。'
+  rescue ActiveRecord::RecordInvalid
+    render :new, status: :unprocessable_content
   end
 
   def edit

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,10 +4,17 @@ class Group < ApplicationRecord
   has_many :members, through: :group_memberships, source: :user
   has_many :proposals, dependent: :destroy
 
-  # TODO: 最大文字数を追加
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 50 }
 
-  # ユーザーが新規グループ作成をした場合に呼び出す想定
+  def process_create!
+    ActiveRecord::Base.transaction do
+      save!
+      add_owner_as_member
+    end
+  end
+
+  private
+
   def add_owner_as_member
     return if members.include?(owner)
 

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -1,4 +1,3 @@
--# TODO: viewのレビューから
 %h1.mb-4= @proposal.title
 
 .d-flex.gap-2.mb-4

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -16,6 +16,21 @@ RSpec.describe Group, type: :model do
           expect(group.errors[:name]).to be_present
         end
       end
+
+      context '名前が50文字の場合' do
+        it '有効であること' do
+          group.name = 'a' * 50
+          expect(group).to be_valid
+        end
+      end
+
+      context '名前が51文字の場合' do
+        it '無効であること' do
+          group.name = 'a' * 51
+          expect(group).not_to be_valid
+          expect(group.errors[:name]).to be_present
+        end
+      end
     end
 
     describe 'オーナー' do


### PR DESCRIPTION
## Summary
- `Group#name` に最大50文字のバリデーションを追加
- グループ作成処理を `process_create!` メソッドでトランザクション化（`vote.rb` の `save_with_status_update!` と同パターン）
- `proposals/show.html.haml` の残存TODOコメントを削除

## Test plan
- [ ] `bundle exec rspec spec/models/group_spec.rb` — name バリデーションテスト確認
- [ ] `bundle exec rspec spec/requests/groups_spec.rb` — グループ作成の正常系・異常系確認

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group creation error handling with transactional safety; validation errors now display consistently.

* **Refactor**
  * Simplified group creation workflow with enhanced exception-based error handling.

* **Validation Changes**
  * Group names now have a maximum length of 50 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->